### PR TITLE
Fix homebrew warning: Warning: Calling string comparison

### DIFF
--- a/homebrew/showmd.rb
+++ b/homebrew/showmd.rb
@@ -7,7 +7,7 @@ cask "showmd" do
   desc "Quick Look extension that renders Markdown beautifully on macOS"
   homepage "https://showmd.yetanother.one"
 
-  depends_on macos: ">= :tahoe"
+  depends_on macos: :tahoe
 
   app "showmd.app"
 


### PR DESCRIPTION
Fixes homebrew warning:

Warning: Calling string comparison format for `depends_on macos:` is deprecated! Use `depends_on macos: :tahoe` instead.