### PR TITLE
Add menu bar mode to hide the Dock icon

### DIFF
--- a/MarkdownRenderer/Sources/MarkdownRenderer/Settings.swift
+++ b/MarkdownRenderer/Sources/MarkdownRenderer/Settings.swift
@@ -27,6 +27,20 @@ public struct Settings {
         case auto, light, dark
     }
 
+    /// Where the host app appears when it is running.
+    ///
+    /// Deliberately not two independent flags: the app always has exactly one
+    /// affordance, so it can never end up hidden from both the Dock and the menu
+    /// bar with no way to reach or quit it.
+    ///
+    /// Host-app only — the Quick Look extension ignores this.
+    public enum Presentation: CaseIterable {
+        case dock, menuBar
+
+        public var showsDockIcon: Bool { self == .dock }
+        public var showsMenuBarItem: Bool { self == .menuBar }
+    }
+
     public enum FontSize: String, CaseIterable {
         case small, medium, large
 
@@ -57,5 +71,14 @@ public struct Settings {
     public static var mermaidEnabled: Bool {
         get { userDefaults.object(forKey: "mermaidEnabled") as? Bool ?? false }
         set { userDefaults.set(newValue, forKey: "mermaidEnabled"); userDefaults.synchronize() }
+    }
+
+    public static var menuBarMode: Bool {
+        get { userDefaults.object(forKey: "menuBarMode") as? Bool ?? false }
+        set { userDefaults.set(newValue, forKey: "menuBarMode"); userDefaults.synchronize() }
+    }
+
+    public static var presentation: Presentation {
+        menuBarMode ? .menuBar : .dock
     }
 }

--- a/MarkdownRenderer/Tests/MarkdownRendererTests/SettingsTests.swift
+++ b/MarkdownRenderer/Tests/MarkdownRendererTests/SettingsTests.swift
@@ -56,4 +56,49 @@ private let testSuiteName = "test.settings"
         Settings.mermaidEnabled = true
         #expect(Settings.mermaidEnabled == true)
     }
+
+    // MARK: - Menu bar mode
+
+    @Test func menuBarModeDefaultsToFalse() {
+        #expect(Settings.menuBarMode == false)
+    }
+
+    @Test func menuBarModeRoundTrips() {
+        Settings.menuBarMode = true
+        #expect(Settings.menuBarMode == true)
+    }
+
+    @Test func menuBarModeFallsBackToFalseForNonBooleanValue() {
+        Settings.userDefaults.set("garbage", forKey: "menuBarMode")
+        #expect(Settings.menuBarMode == false)
+    }
+
+    @Test func presentationDefaultsToDock() {
+        #expect(Settings.presentation == .dock)
+    }
+
+    @Test func presentationFollowsMenuBarMode() {
+        Settings.menuBarMode = true
+        #expect(Settings.presentation == .menuBar)
+        Settings.menuBarMode = false
+        #expect(Settings.presentation == .dock)
+    }
+
+    @Test func dockPresentationShowsOnlyTheDockIcon() {
+        #expect(Settings.Presentation.dock.showsDockIcon)
+        #expect(Settings.Presentation.dock.showsMenuBarItem == false)
+    }
+
+    @Test func menuBarPresentationShowsOnlyTheMenuBarItem() {
+        #expect(Settings.Presentation.menuBar.showsMenuBarItem)
+        #expect(Settings.Presentation.menuBar.showsDockIcon == false)
+    }
+
+    /// The app must never end up with zero affordances — that would leave it
+    /// running with no way to reach or quit it.
+    @Test func everyPresentationHasExactlyOneAffordance() {
+        for presentation in Settings.Presentation.allCases {
+            #expect(presentation.showsDockIcon != presentation.showsMenuBarItem)
+        }
+    }
 }

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Then open **showmd** once, go to **System Settings → Privacy & Security → Ex
 - **Copy as HTML** — one click to copy the rendered output
 - **Dark mode** — follows macOS appearance, or override in settings (Light / Dark / Auto)
 - **Adjustable font size** — Small, Medium, or Large
+- **Menu bar mode** — optionally hide the Dock icon and keep showmd in the menu bar instead
 - **Fully offline** — all JS/CSS dependencies are bundled, no network needed
 - **XSS-hardened** — all user content is escaped and raw HTML is sanitized
 

--- a/ShowMd/AppDelegate.swift
+++ b/ShowMd/AppDelegate.swift
@@ -1,0 +1,44 @@
+import AppKit
+import struct MarkdownRenderer.Settings
+
+// No `MdSettings` typealias here, unlike the SwiftUI files: this file doesn't
+// import SwiftUI, so there's no clash with `SwiftUI.Settings`. A private alias
+// would also leak into `AppPresentation`'s signature, which ContentView calls.
+
+/// Translates the stored presentation preference into an AppKit activation policy.
+///
+/// `.regular` shows the Dock icon; `.accessory` hides it and leaves the menu bar
+/// item as the only affordance. `Settings.Presentation` guarantees exactly one of
+/// the two is active, so showmd can never become unreachable.
+enum AppPresentation {
+    static func policy(for presentation: Settings.Presentation) -> NSApplication.ActivationPolicy {
+        presentation.showsDockIcon ? .regular : .accessory
+    }
+
+    static func apply(_ presentation: Settings.Presentation) {
+        let policy = policy(for: presentation)
+        guard NSApp.activationPolicy() != policy else { return }
+
+        NSApp.setActivationPolicy(policy)
+
+        // Coming back from .accessory, AppKit needs an explicit activation to
+        // restore the main menu and bring the settings window forward.
+        if policy == .regular {
+            NSApp.activate()
+        }
+    }
+}
+
+final class AppDelegate: NSObject, NSApplicationDelegate {
+    /// Applied before launch finishes so the Dock icon never flashes on screen
+    /// when starting in menu bar mode.
+    func applicationWillFinishLaunching(_ notification: Notification) {
+        AppPresentation.apply(Settings.presentation)
+    }
+
+    /// In menu bar mode the window is not the only way back into showmd, so
+    /// closing it leaves the app running. Dock mode keeps the previous behavior.
+    func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
+        !Settings.menuBarMode
+    }
+}

--- a/ShowMd/ContentView.swift
+++ b/ShowMd/ContentView.swift
@@ -90,6 +90,7 @@ struct ContentView: View {
     @State private var theme: MdSettings.Theme = MdSettings.theme
     @State private var fontSize: MdSettings.FontSize = MdSettings.fontSize
     @State private var mermaidEnabled: Bool = MdSettings.mermaidEnabled
+    @State private var menuBarMode: Bool = MdSettings.menuBarMode
     @State private var extensionEnabled: Bool = false
 
     private var version: String {
@@ -100,7 +101,11 @@ struct ContentView: View {
         VStack(spacing: 0) {
             headerView
             Divider()
+            // Sized to its natural height rather than scrolling: combined with
+            // .windowResizability(.contentSize) the window grows to fit every
+            // section, so nothing is clipped as settings are added.
             formView
+                .fixedSize(horizontal: false, vertical: true)
             Divider()
             footerView
         }
@@ -109,6 +114,10 @@ struct ContentView: View {
         .onChange(of: theme)      { _, newValue in MdSettings.theme = newValue }
         .onChange(of: fontSize)   { _, newValue in MdSettings.fontSize = newValue }
         .onChange(of: mermaidEnabled) { _, newValue in MdSettings.mermaidEnabled = newValue }
+        .onChange(of: menuBarMode) { _, newValue in
+            MdSettings.menuBarMode = newValue
+            AppPresentation.apply(MdSettings.presentation)
+        }
         .preferredColorScheme(theme == .light ? .light : theme == .dark ? .dark : nil)
         .onAppear { checkExtensionEnabled { extensionEnabled = $0 } }
         .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
@@ -185,6 +194,15 @@ struct ContentView: View {
             } header: {
                 Text("Appearance")
             }
+
+            Section {
+                Toggle("Show in Menu Bar Instead of Dock", isOn: $menuBarMode)
+                Text("Hide the Dock icon and keep showmd in the menu bar. Quick Look previews work the same either way.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            } header: {
+                Text("General")
+            }
         }
         .formStyle(.grouped)
     }
@@ -200,9 +218,7 @@ struct ContentView: View {
             }
             Spacer()
             Button(extensionEnabled ? "Manage" : "Enable") {
-                if let url = URL(string: "x-apple.systempreferences:com.apple.ExtensionsPreferences") {
-                    NSWorkspace.shared.open(url)
-                }
+                SystemSettings.openQuickLookExtensions()
             }
             .buttonStyle(.link)
             .font(.caption)

--- a/ShowMd/ShowMdApp.swift
+++ b/ShowMd/ShowMdApp.swift
@@ -1,15 +1,57 @@
 import SwiftUI
+import struct MarkdownRenderer.Settings
+
+private typealias MdSettings = Settings
+
+private let mainWindowID = "main"
 
 @main
 struct ShowMdApp: App {
+    @NSApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
+
+    /// Bound to `MenuBarExtra`'s `isInserted`, so the item appears and disappears
+    /// as soon as the preference changes — no relaunch needed.
+    @AppStorage("menuBarMode", store: MdSettings.userDefaults)
+    private var menuBarMode = false
+
     var body: some Scene {
-        WindowGroup("showmd") {
+        // A single `Window` rather than a `WindowGroup`: "Open showmd" should
+        // focus the existing settings window, not open a second copy of it.
+        Window("showmd", id: mainWindowID) {
             ContentView()
         }
         .windowResizability(.contentSize)
         .defaultSize(width: 460, height: 480)
         .commands {
             CommandGroup(replacing: .newItem) {}
+        }
+
+        MenuBarExtra("showmd", systemImage: "doc.text.magnifyingglass", isInserted: $menuBarMode) {
+            MenuBarMenu()
+        }
+    }
+}
+
+/// Contents of the menu bar dropdown, kept as a view so it can read `openWindow`
+/// from the environment.
+private struct MenuBarMenu: View {
+    @Environment(\.openWindow) private var openWindow
+
+    var body: some View {
+        Button("Open showmd") {
+            NSApp.activate()
+            openWindow(id: mainWindowID)
+        }
+
+        Button("Quick Look Extension Settings…") {
+            SystemSettings.openQuickLookExtensions()
+        }
+
+        Divider()
+
+        // With the Dock icon hidden, this is the only way to quit.
+        Button("Quit showmd") {
+            NSApp.terminate(nil)
         }
     }
 }

--- a/ShowMd/SystemSettings.swift
+++ b/ShowMd/SystemSettings.swift
@@ -1,0 +1,10 @@
+import AppKit
+
+/// System Settings deep links, shared by the settings window and the menu bar menu.
+enum SystemSettings {
+    /// Opens System Settings → Privacy & Security → Extensions → Quick Look.
+    static func openQuickLookExtensions() {
+        guard let url = URL(string: "x-apple.systempreferences:com.apple.ExtensionsPreferences") else { return }
+        NSWorkspace.shared.open(url)
+    }
+}

--- a/superpowers/specs/2026-07-19-menu-bar-mode-design.md
+++ b/superpowers/specs/2026-07-19-menu-bar-mode-design.md
@@ -1,0 +1,153 @@
+# Menu Bar Mode — Design
+
+**Date:** 2026-07-19
+**Status:** Approved
+
+## Problem
+
+showmd's host app is a settings panel for the Quick Look extension. Users open it
+once to configure theme, font size, and Mermaid, then rarely again — but it keeps a
+permanent Dock icon. Users who want showmd out of the Dock currently have no option.
+
+## Goal
+
+Add a preference that hides the Dock icon and puts showmd in the menu bar instead.
+
+## Non-goals
+
+- Showing in both the Dock and the menu bar simultaneously.
+- Changing Quick Look preview behavior. Previews are handled by the extension and
+  are unaffected by this preference.
+- A menu bar popover UI. The menu bar item opens the existing settings window.
+
+## Model
+
+A single preference with two states, not two independent toggles:
+
+| `menuBarMode` | Dock icon | Menu bar item |
+|---------------|-----------|---------------|
+| `false` (default) | shown | hidden |
+| `true` | hidden | shown |
+
+One toggle makes the invalid state — neither affordance present, leaving the app
+unreachable — unrepresentable. The `Presentation` enum below encodes this so the
+invariant is testable rather than merely intended.
+
+## Architecture
+
+The split follows what CI can verify. `.github/workflows/test.yml` runs only
+`cd MarkdownRenderer && swift test`; the `ShowMd` app target is never compiled in
+CI. So decision logic lives in the package where tests reach it, and AppKit is a
+thin adapter over that decision.
+
+### Package layer — `MarkdownRenderer/Sources/MarkdownRenderer/Settings.swift`
+
+```swift
+public enum Presentation: CaseIterable {
+    case dock, menuBar
+    public var showsDockIcon: Bool     { self == .dock }
+    public var showsMenuBarItem: Bool  { self == .menuBar }
+}
+
+public static var menuBarMode: Bool      // stored, App Group UserDefaults, default false
+public static var presentation: Presentation  // derived: menuBarMode ? .menuBar : .dock
+```
+
+`Bool` storage matches the existing `mermaidEnabled` pattern; `theme`/`fontSize`/
+`defaultTab` use enums because they have three states each.
+
+`Presentation` imports nothing beyond Foundation. This is deliberate — CI builds
+this package on a `macos-15` runner, and the package is also linked into the
+sandboxed Quick Look extension, which has no business importing AppKit.
+
+Per `tasks/lessons.md`, no `@MainActor` on these properties: `UserDefaults` is
+thread-safe and annotating it would constrain every call site.
+
+### App layer — `ShowMd/`
+
+**`AppDelegate.swift`** (new)
+
+- `AppPresentation.policy(for:)` — maps `Presentation.showsDockIcon` to
+  `.regular` / `.accessory`. Pure function, kept separate from the side effect.
+- `AppPresentation.apply(_:)` — sets the policy, no-op if unchanged. On the
+  `.accessory → .regular` transition it calls `NSApp.activate()`, which AppKit
+  needs to restore the main menu and bring the window forward.
+- `applicationWillFinishLaunching` — applies the policy early enough that the Dock
+  icon never flashes when launching in menu bar mode.
+- `applicationShouldTerminateAfterLastWindowClosed` — returns `!menuBarMode`. In
+  menu bar mode the window is not the only affordance, so closing it leaves showmd
+  running; Dock mode keeps today's quit-on-close behavior exactly.
+
+**`ShowMdApp.swift`**
+
+- `WindowGroup("showmd")` → `Window("showmd", id: "main")`. Required so
+  `openWindow(id:)` from the menu focuses the existing settings window instead of
+  spawning a duplicate every time. `Window` is also the correct primitive for a
+  single settings panel — this is a simplification, not added machinery.
+- `MenuBarExtra(..., systemImage: "doc.text.magnifyingglass", isInserted:)` bound
+  to `@AppStorage("menuBarMode", store: Settings.userDefaults)`, so the item
+  appears and disappears live without a relaunch. The `systemImage:` initializer
+  renders as a template image, so it adapts to light and dark menu bars.
+- Menu contents: *Open showmd* · *Quick Look Extension Settings…* · separator ·
+  *Quit showmd*. Quit matters — with no Dock icon there is otherwise no obvious
+  way to quit.
+
+**`SystemSettings.swift`** (new, small)
+
+Extracts the `x-apple.systempreferences:com.apple.ExtensionsPreferences` URL,
+which is now needed by both `ContentView.extensionStatusRow` and the menu bar
+menu. Removes duplication this change would otherwise introduce.
+
+**`ContentView.swift`**
+
+New `General` section at the end of the form with the toggle and a caption,
+following the file's existing `@State` + `.onChange` → `MdSettings.x` pattern.
+Uses the `MdSettings` typealias already established in the file, per the
+`SwiftUI.Settings` name-clash lesson in `tasks/lessons.md`.
+
+`Info.plist` is untouched. `LSUIElement` would hard-code accessory mode; the
+policy is applied at runtime instead so the preference can be toggled live.
+
+## Data flow
+
+```
+ContentView toggle
+  → Settings.menuBarMode (App Group UserDefaults)
+      ├→ AppPresentation.apply()  → NSApp.setActivationPolicy()   [Dock icon]
+      └→ @AppStorage KVO          → MenuBarExtra isInserted        [menu bar item]
+```
+
+Both observers read the same key, so the two affordances cannot drift apart.
+
+## Testing
+
+Eight tests added to `SettingsTests.swift`:
+
+- `menuBarMode` — defaults to false, round-trips, falls back to false on a
+  non-boolean stored value (mirrors the existing `unknownRawValueFallsBackToDefault`)
+- `presentation` — defaults to `.dock`, tracks `menuBarMode` in both directions
+- `Presentation` — `.dock` exposes only the Dock icon, `.menuBar` only the menu bar
+  item, and across `allCases` exactly one affordance is always active
+
+**XSS tests: not applicable.** This adds no rendering path and puts no
+user-supplied content into HTML. `CONTRIBUTING.md` rule 5 governs `MarkdownRenderer`
+HTML output; this change touches only `UserDefaults` and AppKit state.
+
+**Entitlements: untouched.** `CONTRIBUTING.md` rule 6 and the
+`com.apple.security.network.client` incident in `tasks/lessons.md` are not in play.
+
+The `ShowMd` app target is unreachable from `swift test` — the same limitation
+`tasks/lessons.md` already records for WKWebView rendering. Covered by building and
+manually exercising the app: toggle both directions, confirm the Dock icon and menu
+bar item swap, each menu item works, closing the window in menu bar mode leaves the
+app running, and the setting survives a relaunch.
+
+## Risks
+
+| Risk | Mitigation |
+|------|-----------|
+| App unreachable with no Dock icon and no menu bar item | `Presentation` makes the state unrepresentable; covered by the exactly-one-affordance test |
+| No way to quit without a Dock icon | Explicit *Quit showmd* menu item |
+| Dock icon flashes at launch in menu bar mode | Policy applied in `applicationWillFinishLaunching`, before the icon is drawn |
+| Menu bar returns empty after `.accessory → .regular` | `AppPresentation.apply` re-activates on that transition |
+| App quits when the window closes in menu bar mode | `applicationShouldTerminateAfterLastWindowClosed` returns false in that mode |

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -154,6 +154,77 @@ The single-argument closure form is deprecated on macOS 14+. Use the two-argumen
 
 `Form { }.formStyle(.grouped)` is the macOS-native pattern for settings panels — no custom card styling needed.
 
+### windowResizability(.contentSize) ignores defaultSize — the Form must not scroll
+
+`.windowResizability(.contentSize)` sizes the window to the content's *ideal* height.
+A `Form` is scrollable, so its ideal height is indeterminate and SwiftUI settles on a
+short default — the window then clips the last section, and `.defaultSize(height:)`
+has no effect because `.contentSize` overrides it.
+
+**Fix:** make the form report its natural height so the window can grow to fit.
+
+```swift
+formView
+    .fixedSize(horizontal: false, vertical: true)
+```
+
+Do NOT "fix" this by bumping `.defaultSize` (ignored) or hard-coding a total window
+height (breaks the next time a section is added). This bug silently clipped the
+Appearance section for several releases before it was noticed.
+
+### Saved window frames mask sizing changes during testing
+
+macOS persists the window frame in `NSWindow Frame <autosaveName>` under the app's
+defaults domain and in `~/Library/Saved Application State/`. A rebuilt app restores
+the old frame, so window-sizing changes appear to do nothing. Clear both before
+testing sizing:
+
+```bash
+rm -rf ~/Library/"Saved Application State"/one.yetanother.showmd.app.savedState
+defaults delete one.yetanother.showmd.app
+```
+
+---
+
+## Dock vs Menu Bar Presentation
+
+### Toggle activation policy at runtime, not via LSUIElement
+
+`LSUIElement` in `Info.plist` hard-codes accessory mode and cannot be changed while
+running. For a *user-toggleable* preference, leave the plist alone and call
+`NSApp.setActivationPolicy(.accessory / .regular)` instead.
+
+Apply it in `applicationWillFinishLaunching` — later than that (e.g.
+`applicationDidFinishLaunching`) and the Dock icon visibly flashes before it is hidden.
+
+Returning `.accessory → .regular` needs an explicit `NSApp.activate()`, or the app
+comes forward with no main menu.
+
+### Model presentation as one enum, never two booleans
+
+Two independent flags ("show in Dock", "show in menu bar") admit a state where both
+are off and the app is running with no way to reach or quit it. A single
+`Settings.Presentation` enum (`.dock` / `.menuBar`) makes that unrepresentable, and
+the invariant is unit-testable in the package without importing AppKit — which
+matters because CI builds `MarkdownRenderer` on a `macos-15` runner and the package
+is also linked into the sandboxed Quick Look extension.
+
+Always include a **Quit** item in the menu bar menu: with the Dock icon hidden there
+is no other obvious way to quit.
+
+### Window vs WindowGroup for a single settings panel
+
+`WindowGroup` + `openWindow(id:)` opens a *new* window each time. Use `Window` so the
+menu bar's "Open showmd" focuses the existing settings window instead of stacking
+duplicates.
+
+### private typealias leaks into internal signatures
+
+`private typealias MdSettings = Settings` (the `SwiftUI.Settings` clash workaround)
+cannot appear in an `internal` function signature — "method must be declared
+fileprivate because its parameter uses a private type". Files that don't import
+SwiftUI have no clash to work around, so reference `Settings` directly there.
+
 ---
 
 ## Git Hygiene
@@ -221,14 +292,14 @@ When adding a feature, always add tests for:
 3. **XSS vectors** — try injecting `<script>`, event handlers, and `javascript:` URLs through every input path
 4. **Negative cases** — e.g. source-only template should NOT include rich feature scripts
 
-### Current test suites (51 tests total)
+### Current test suites (150 tests total)
 
 | Suite | What it covers |
 |-------|---------------|
 | `HTMLVisitorTests` | Every markdown element → HTML conversion: text, bold, italic, inline code, links, images, headings, code blocks (plain + language-specific + mermaid), blockquotes, lists, tables, task lists, strikethrough, HTML escaping |
 | `HTMLTemplateTests` | Template wrapping: DOCTYPE, body injection, theme attribute, font size, source body class, color-scheme meta, rich feature CDN inclusion (highlight.js, KaTeX, Mermaid), combined template tabs, frontmatter HTML |
 | `MarkdownRendererTests` | Public API: full render, theme application, font size, source HTML escaping |
-| `SettingsTests` | UserDefaults round-trips for all settings, defaults, CSS values, unknown raw value fallback |
+| `SettingsTests` | UserDefaults round-trips for all settings, defaults, CSS values, unknown raw value fallback, Dock/menu bar presentation mapping |
 
 ### Running tests
 


### PR DESCRIPTION
## What

Adds a **Show in Menu Bar Instead of Dock** preference. When enabled, showmd runs as an accessory app — no Dock icon — with a menu bar item offering *Open showmd*, *Quick Look Extension Settings…*, and *Quit showmd*.

Since the host app is mostly a settings panel you configure once, a permanent Dock icon isn't always wanted. Quick Look previews are unaffected either way.

## Design notes

**One enum, not two booleans.** Presentation is modelled as `Settings.Presentation` (`.dock` / `.menuBar`) rather than independent "show in Dock" / "show in menu bar" flags. Two flags admit a state where both are off, leaving the app running with no way to reach or quit it. The enum makes that unrepresentable, and the invariant is covered by a test.

**Kept AppKit out of the package.** `Presentation` is Foundation-only, so it stays testable on the `macos-15` CI runner and the sandboxed Quick Look extension can keep linking `MarkdownRenderer` without pulling in AppKit. `ShowMd/AppDelegate.swift` is a thin adapter mapping it to an `NSApplication.ActivationPolicy`.

**Runtime policy, not `LSUIElement`.** `Info.plist` is untouched — `LSUIElement` hard-codes accessory mode and would defeat a user-facing toggle. The policy is applied in `applicationWillFinishLaunching` so the Dock icon never flashes on launch, and `applicationShouldTerminateAfterLastWindowClosed` returns `false` in menu bar mode so closing the window leaves the app running. Dock mode behaviour is unchanged.

**`Window` instead of `WindowGroup`.** So the menu's "Open showmd" focuses the existing settings window rather than stacking duplicates. This is the one structural change to the existing scene.

## Also fixes a pre-existing clipping bug

The settings window was cutting off its last section — in v1.0.2 **Theme and Font Size are clipped and only reachable by scrolling**. `.windowResizability(.contentSize)` sizes the window to the content's *ideal* height; a scrollable `Form` reports an indeterminate one, so `.defaultSize(height:)` was silently ignored. Adding a fourth section made it obvious.

Fixed with `.fixedSize(horizontal: false, vertical: true)` on the form, so the window grows to fit whatever sections exist. Included here because this change surfaced it — happy to split it into a separate PR if you'd prefer.

## Testing

`cd MarkdownRenderer && swift test` — **150 tests pass**, including 8 new ones covering the stored preference (default, round-trip, non-boolean fallback) and the presentation mapping, plus an `everyPresentationHasExactlyOneAffordance` invariant test.

The `ShowMd` target isn't reachable from `swift test` (same limitation `tasks/lessons.md` records for WKWebView), so it was verified by building and exercising the app:

- Dock mode → `ApplicationType="Foreground"`, no menu bar item
- Menu bar mode → `ApplicationType="UIElement"`, Dock icon gone, menu bar item present
- Toggling live switches presentation without a relaunch, both directions
- All three menu items work; "Open showmd" focuses the existing window
- Closing the window in menu bar mode leaves the app running
- Preference persists across relaunch, no Dock icon flash

## CONTRIBUTING checklist

- ✅ **Tests** — 8 added for the `MarkdownRenderer` change
- ✅ **XSS** — N/A, no rendering path touched and no user content reaches HTML
- ✅ **Entitlements** — untouched
- ✅ **`tasks/lessons.md`** — read, and extended with the activation-policy, window-sizing, and presentation-modelling lessons. Also corrected a stale test count (51 → 150).
- ⚠️ **Root `CLAUDE.md`** — rule 3 references one, but no `CLAUDE.md` has ever existed at the repo root in any commit; the only one is `superpowers/specs/CLAUDE.md`. I followed that file (its Task Management section is why `tasks/todo.md` is included, with a Review section). You may want to fix the path in `CONTRIBUTING.md`.